### PR TITLE
Sort type definitions alphabetically by keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export const toFlow = (flowSchema: FlowSchema): Object =>
 export const schemaToFlow = (flowSchema: FlowSchema): string =>
   _.map(
     [
-      ...(_.map(flowSchema.$definitions, toFlow)),
+      ...(_(flowSchema.$definitions).toPairs().sortBy(0).flatMap(pair => toFlow(pair[1])).value()),
       toFlow(flowSchema),
     ],
     (ast: Object): string => generate(ast).code,


### PR DESCRIPTION
This ensures a deterministic output for the generator. Currently we are relying on the iteration order of the input JSON schema object, that order is undefined behavior and could be subject to change.
It means if we're giving the same object as input to the generator, but the iteration order happens to change, the generated output will change also.

This updates the code to sort the types definitions alphabetically.
But it doesn't sort the properties, so I will probably add that too?