### PR TITLE
Fix dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "fs-extra": "1.0.0"
   },
   "dependencies": {
-    "@babel/generator": "^7.0.0-beta.44",
-    "@babel/types": "^7.0.0-beta.44",
+    "@babel/generator": "7.0.0-beta.44",
+    "@babel/types": "7.0.0-beta.44",
     "eslint-plugin-flow": "^2.29.1",
     "lodash": "4.17.x"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,7 +43,7 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.44"
 
-"@babel/generator@7.0.0-beta.44", "@babel/generator@^7.0.0-beta.44":
+"@babel/generator@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
   dependencies:
@@ -105,7 +105,7 @@
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-"@babel/types@7.0.0-beta.44", "@babel/types@^7.0.0-beta.40", "@babel/types@^7.0.0-beta.44":
+"@babel/types@7.0.0-beta.44", "@babel/types@^7.0.0-beta.40":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
   dependencies:


### PR DESCRIPTION
Hi!

I think that it is better to strictly depend on the dependent version in order to avoid situations like #27 and #28.

In particular, the `@babel/*` package is still in beta, so I think there is a possibility that big changes will continue in the future.